### PR TITLE
cw - create Help Request controllers, added GET(index) and POST (create)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/HelpRequestController.java
@@ -1,0 +1,74 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Api(description = "HelpRequest")
+@RequestMapping("/api/HelpRequest")
+@RestController
+@Slf4j
+public class HelpRequestController extends ApiController {
+
+    @Autowired
+    HelpRequestRepository helpRequestRepository;
+
+    @ApiOperation(value = "List all help requests")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<HelpRequest> allHelpRequests() {
+        Iterable<HelpRequest> requests = helpRequestRepository.findAll();
+        return requests;
+    }
+
+    @ApiOperation(value = "Create a new help request")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public HelpRequest postHelpRequest(
+            @ApiParam("requesterEmail") @RequestParam String requesterEmail,
+            @ApiParam("teamId") @RequestParam String teamId,
+            @ApiParam("tableOrBreakoutRoom") @RequestParam String tableOrBreakoutRoom,
+            @ApiParam("date (in iso format, e.g. YYYY-mm-ddTHH:MM:SS)") @RequestParam("requestTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime requestTime,
+            @ApiParam("explanation") @RequestParam String explanation,
+            @ApiParam("solved") @RequestParam boolean solved)
+            throws JsonProcessingException {
+
+        log.info("requestTime={}", requestTime);
+
+        HelpRequest helpRequest = new HelpRequest();
+        helpRequest.setRequesterEmail(requesterEmail);
+        helpRequest.setTeamId(teamId);
+        helpRequest.setTableOrBreakoutRoom(tableOrBreakoutRoom);
+        helpRequest.setRequestTime(requestTime);
+        helpRequest.setExplanation(explanation);
+        helpRequest.setSolved(solved);
+
+        HelpRequest savedHelpRequest = helpRequestRepository.save(helpRequest);
+
+        return savedHelpRequest;
+    }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,4 +1,4 @@
-package main.java.edu.ucsb.cs156.example.entities;
+package edu.ucsb.cs156.example.entities;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/HelpRequest.java
@@ -1,0 +1,31 @@
+package main.java.edu.ucsb.cs156.example.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "helprequest")
+public class HelpRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+ 
+  String requesterEmail;
+  String teamId;
+  String tableOrBreakoutRoom;
+  LocalDateTime requestTime;
+  String explanation;
+  boolean solved;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,6 +1,6 @@
-package main.java.edu.ucsb.cs156.example.repositories;
+package edu.ucsb.cs156.example.repositories;
 
-import main.java.edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.entities.HelpRequest;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/HelpRequestRepository.java
@@ -1,0 +1,12 @@
+package main.java.edu.ucsb.cs156.example.repositories;
+
+import main.java.edu.ucsb.cs156.example.entities.HelpRequest;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface HelpRequestRepository extends CrudRepository<HelpRequest, Long> {
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/HelpRequestControllerTests.java
@@ -1,0 +1,329 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = HelpRequestController.class)
+@Import(TestConfig.class)
+public class HelpRequestControllerTests extends ControllerTestCase {
+
+        @MockBean
+        HelpRequestRepository helpRequestRepository;
+
+        @MockBean
+        UserRepository userRepository;
+
+        // Authorization tests for /api/HelpRequest/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/HelpRequest/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/HelpRequest/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+        // @Test
+        // public void logged_out_users_cannot_get_by_id() throws Exception {
+        //         mockMvc.perform(get("/api/HelpRequest?id=7"))
+        //                         .andExpect(status().is(403)); // logged out users can't get by id
+        // }
+
+        // Authorization tests for /api/HelpRequest/post
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/HelpRequest/post"))
+                                .andExpect(status().is(403));
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+                mockMvc.perform(post("/api/HelpRequest/post"))
+                                .andExpect(status().is(403)); // only admins can post
+        }
+
+        // // Tests with mocks for database actions
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+        //         // arrange
+        //         LocalDateTime ldt = LocalDateTime.parse("2022-04-20T17:35:00");
+
+        //         HelpRequest helpRequest = HelpRequest.builder()
+        //                         .requesterEmail("cgaucho@ucsb.edu")
+        //                         .teamId("s22-5pm-3")
+        //                         .tableOrBreakoutRoom("7")
+        //                         .requestTime(ldt)
+        //                         .explanation("Need help with Swagger-ui")
+        //                         .solved(false)
+        //                         .build();
+
+        //         when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.of(helpRequest));
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
+        //                         .andExpect(status().isOk()).andReturn();
+
+        //         // assert
+
+        //         verify(helpRequestRepository, times(1)).findById(eq(7L));
+        //         String expectedJson = mapper.writeValueAsString(helpRequest);
+        //         String responseString = response.getResponse().getContentAsString();
+        //         assertEquals(expectedJson, responseString);
+        // }
+
+        // @WithMockUser(roles = { "USER" })
+        // @Test
+        // public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+        //         // arrange
+
+        //         when(helpRequestRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        //         // act
+        //         MvcResult response = mockMvc.perform(get("/api/HelpRequest?id=7"))
+        //                         .andExpect(status().isNotFound()).andReturn();
+
+        //         // assert
+
+        //         verify(helpRequestRepository, times(1)).findById(eq(7L));
+        //         Map<String, Object> json = responseToJson(response);
+        //         assertEquals("EntityNotFoundException", json.get("type"));
+        //         assertEquals("HelpRequest with id 7 not found", json.get("message"));
+        // }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_helprequests() throws Exception {
+
+                // arrange
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .teamId("s22-5pm-3")
+                                .tableOrBreakoutRoom("7")
+                                .requestTime(ldt1)
+                                .explanation("Need help with Swagger-ui")
+                                .solved(false)
+                                .build();
+
+                LocalDateTime ldt2 = LocalDateTime.parse("2022-04-20T18:31:00");
+
+                HelpRequest helpRequest2 = HelpRequest.builder()
+                                .requesterEmail("ldelplaya@ucsb.edu")
+                                .teamId("s22-6pm-3")
+                                .tableOrBreakoutRoom("11")
+                                .requestTime(ldt2)
+                                .explanation("Heroku problems")
+                                .solved(false)
+                                .build();
+
+                ArrayList<HelpRequest> expectedRequests = new ArrayList<>();
+                expectedRequests.addAll(Arrays.asList(helpRequest1, helpRequest2));
+
+                when(helpRequestRepository.findAll()).thenReturn(expectedRequests);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/HelpRequest/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(helpRequestRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequests);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void an_admin_user_can_post_a_new_ucsbdate() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-04-20T17:35:00");
+
+                HelpRequest helpRequest1 = HelpRequest.builder()
+                                .requesterEmail("cgaucho@ucsb.edu")
+                                .teamId("s22-5pm-3")
+                                .tableOrBreakoutRoom("7")
+                                .requestTime(ldt1)
+                                .explanation("NeedhelpwithSwagger-ui")
+                                .solved(false)
+                                .build();
+
+                when(helpRequestRepository.save(eq(helpRequest1))).thenReturn(helpRequest1);
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                post("/api/HelpRequest/post?requesterEmail=cgaucho@ucsb.edu&teamId=s22-5pm-3&tableOrBreakoutRoom=7&requestTime=2022-04-20T17:35:00&explanation=NeedhelpwithSwagger-ui&solved=false")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(helpRequestRepository, times(1)).save(helpRequest1);
+                String expectedJson = mapper.writeValueAsString(helpRequest1);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+//         @WithMockUser(roles = { "ADMIN", "USER" })
+//         @Test
+//         public void admin_can_delete_a_date() throws Exception {
+//                 // arrange
+
+//                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+//                 UCSBDate ucsbDate1 = UCSBDate.builder()
+//                                 .name("firstDayOfClasses")
+//                                 .quarterYYYYQ("20222")
+//                                 .localDateTime(ldt1)
+//                                 .build();
+
+//                 when(ucsbDateRepository.findById(eq(15L))).thenReturn(Optional.of(ucsbDate1));
+
+//                 // act
+//                 MvcResult response = mockMvc.perform(
+//                                 delete("/api/ucsbdates?id=15")
+//                                                 .with(csrf()))
+//                                 .andExpect(status().isOk()).andReturn();
+
+//                 // assert
+//                 verify(ucsbDateRepository, times(1)).findById(15L);
+//                 verify(ucsbDateRepository, times(1)).delete(any());
+
+//                 Map<String, Object> json = responseToJson(response);
+//                 assertEquals("UCSBDate with id 15 deleted", json.get("message"));
+//         }
+
+//         @WithMockUser(roles = { "ADMIN", "USER" })
+//         @Test
+//         public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+//                         throws Exception {
+//                 // arrange
+
+//                 when(ucsbDateRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+//                 // act
+//                 MvcResult response = mockMvc.perform(
+//                                 delete("/api/ucsbdates?id=15")
+//                                                 .with(csrf()))
+//                                 .andExpect(status().isNotFound()).andReturn();
+
+//                 // assert
+//                 verify(ucsbDateRepository, times(1)).findById(15L);
+//                 Map<String, Object> json = responseToJson(response);
+//                 assertEquals("UCSBDate with id 15 not found", json.get("message"));
+//         }
+
+//         @WithMockUser(roles = { "ADMIN", "USER" })
+//         @Test
+//         public void admin_can_edit_an_existing_ucsbdate() throws Exception {
+//                 // arrange
+
+//                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+//                 LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+//                 UCSBDate ucsbDateOrig = UCSBDate.builder()
+//                                 .name("firstDayOfClasses")
+//                                 .quarterYYYYQ("20222")
+//                                 .localDateTime(ldt1)
+//                                 .build();
+
+//                 UCSBDate ucsbDateEdited = UCSBDate.builder()
+//                                 .name("firstDayOfFestivus")
+//                                 .quarterYYYYQ("20232")
+//                                 .localDateTime(ldt2)
+//                                 .build();
+
+//                 String requestBody = mapper.writeValueAsString(ucsbDateEdited);
+
+//                 when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.of(ucsbDateOrig));
+
+//                 // act
+//                 MvcResult response = mockMvc.perform(
+//                                 put("/api/ucsbdates?id=67")
+//                                                 .contentType(MediaType.APPLICATION_JSON)
+//                                                 .characterEncoding("utf-8")
+//                                                 .content(requestBody)
+//                                                 .with(csrf()))
+//                                 .andExpect(status().isOk()).andReturn();
+
+//                 // assert
+//                 verify(ucsbDateRepository, times(1)).findById(67L);
+//                 verify(ucsbDateRepository, times(1)).save(ucsbDateEdited); // should be saved with correct user
+//                 String responseString = response.getResponse().getContentAsString();
+//                 assertEquals(requestBody, responseString);
+//         }
+
+//         @WithMockUser(roles = { "ADMIN", "USER" })
+//         @Test
+//         public void admin_cannot_edit_ucsbdate_that_does_not_exist() throws Exception {
+//                 // arrange
+
+//                 LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+//                 UCSBDate ucsbEditedDate = UCSBDate.builder()
+//                                 .name("firstDayOfClasses")
+//                                 .quarterYYYYQ("20222")
+//                                 .localDateTime(ldt1)
+//                                 .build();
+
+//                 String requestBody = mapper.writeValueAsString(ucsbEditedDate);
+
+//                 when(ucsbDateRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+//                 // act
+//                 MvcResult response = mockMvc.perform(
+//                                 put("/api/ucsbdates?id=67")
+//                                                 .contentType(MediaType.APPLICATION_JSON)
+//                                                 .characterEncoding("utf-8")
+//                                                 .content(requestBody)
+//                                                 .with(csrf()))
+//                                 .andExpect(status().isNotFound()).andReturn();
+
+//                 // assert
+//                 verify(ucsbDateRepository, times(1)).findById(67L);
+//                 Map<String, Object> json = responseToJson(response);
+//                 assertEquals("UCSBDate with id 67 not found", json.get("message"));
+
+//        }
+}


### PR DESCRIPTION
In this PR, we created the controller and controller tests, and added the GET and POST endpoints that can be used to list all database records and create new database records respectively. 